### PR TITLE
markdown追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@types/react": "16.8.21",
     "@types/react-dom": "16.8.4",
     "@types/webpack-env": "^1.13.9",
+    "marked": "^0.6.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-scripts": "3.0.1",
@@ -34,6 +35,7 @@
     ]
   },
   "devDependencies": {
+    "@types/marked": "^0.6.5",
     "@typescript-eslint/eslint-plugin": "^1.9.0",
     "@typescript-eslint/parser": "^1.9.0",
     "@typescript-eslint/typescript-estree": "^1.9.0",

--- a/src/components/PaperNote.tsx
+++ b/src/components/PaperNote.tsx
@@ -7,6 +7,7 @@ import {
 } from '@material-ui/core'
 import React, { FunctionComponent, useState } from 'react'
 import { Note } from '../types/note'
+import { createMarkup } from '../helpers/createMarkup'
 
 type Props = {
   onUpdateNote: (note: Note) => void
@@ -41,6 +42,7 @@ const PaperNote: FunctionComponent<Props> = ({ onUpdateNote, note }) => {
         multiline
         onBlur={onBlur}
       />
+      <div dangerouslySetInnerHTML={createMarkup(text)} />
     </Paper>
   )
 }

--- a/src/helpers/createMarkup.ts
+++ b/src/helpers/createMarkup.ts
@@ -1,0 +1,6 @@
+import marked from 'marked'
+
+marked.setOptions({ breaks: true })
+export const createMarkup = (text: string) => {
+  return { __html: marked(text) }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "strict": true,
-    "target": "es5"
+    "target": "es5",
+    "allowJs": true
   },
   "include": ["src"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1361,6 +1361,11 @@
   dependencies:
     "@types/jest-diff" "*"
 
+"@types/marked@^0.6.5":
+  version "0.6.5"
+  resolved "https://registry.yarnpkg.com/@types/marked/-/marked-0.6.5.tgz#3cf2a56ef615dad24aaf99784ef90a9eba4e29d8"
+  integrity sha512-6kBKf64aVfx93UJrcyEZ+OBM5nGv4RLsI6sR1Ar34bpgvGVRoyTgpxn4ZmtxOM5aDTAaaznYuYUH8bUX3Nk3YA==
+
 "@types/node@*":
   version "12.0.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.0.0.tgz#d11813b9c0ff8aaca29f04cbc12817f4c7d656e5"
@@ -6365,6 +6370,11 @@ map-visit@^1.0.0:
   integrity sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=
   dependencies:
     object-visit "^1.0.0"
+
+marked@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-0.6.2.tgz#c574be8b545a8b48641456ca1dbe0e37b6dccc1a"
+  integrity sha512-LqxwVH3P/rqKX4EKGz7+c2G9r98WeM/SW34ybhgNGhUQNKtf1GmmSkJ6cDGJ/t6tiyae49qRkpyTw2B9HOrgUA==
 
 md5.js@^1.3.4:
   version "1.3.5"


### PR DESCRIPTION
markdownで書いたテキストをhtmlで表示できるようにした。
とりあえずPaperNote.tsxのtextareaの下にdiv置いたけど何処にどんな風に表示させるか検討の余地あり
(ここに置くにしても区切り線とか薄い背景色をしくとかして入力と別のエリアだとわかるようにしたい)

![スクリーンショット 2019-06-24 1 02 19](https://user-images.githubusercontent.com/29856021/59978838-c383f800-961b-11e9-88b1-e4608637e6b9.png)
