### PR TITLE
previewとinputを出し分ける

### DIFF
--- a/src/components/DivNotePreview.tsx
+++ b/src/components/DivNotePreview.tsx
@@ -1,11 +1,34 @@
 import React, { FunctionComponent } from 'react'
 import { Note } from '../firestore/types/note'
 import { createMarkup } from '../helpers/createMarkup'
+import { makeStyles, Theme } from '@material-ui/core'
 
-type Props = { note: Note }
-
-const DivNotePreview: FunctionComponent<Props> = ({ note }) => {
-  return <div dangerouslySetInnerHTML={createMarkup(note.text)} />
+type Props = {
+  note: Note
+  handlePreviewHide: (boolean: boolean) => void
 }
+
+const DivNotePreview: FunctionComponent<Props> = ({
+  note,
+  handlePreviewHide
+}) => {
+  const classes = useStyles()
+  return (
+    <div
+      className={classes.root}
+      dangerouslySetInnerHTML={createMarkup(note.text)}
+      onClick={() => handlePreviewHide(true)}
+    />
+  )
+}
+
+const useStyles = makeStyles<Theme>(() => {
+  return {
+    root: {
+      width: '100%',
+      height: '100%'
+    }
+  }
+})
 
 export default DivNotePreview

--- a/src/components/InputBaseNoteText.tsx
+++ b/src/components/InputBaseNoteText.tsx
@@ -11,12 +11,14 @@ type Props = {
   inProgress: boolean
   note: Note
   onUpdateNote: (change: Change) => void
+  handlePreviewHide: (boolean: boolean) => void
 }
 
 const InputBaseNoteText: FunctionComponent<Props> = ({
   inProgress,
   note,
-  onUpdateNote
+  onUpdateNote,
+  handlePreviewHide
 }) => {
   const [text, setText] = useState(note.text)
 
@@ -28,12 +30,13 @@ const InputBaseNoteText: FunctionComponent<Props> = ({
         onChange={e => setText(e.target.value)}
         fullWidth
         multiline
+        autoFocus
         onBlur={() => {
           onUpdateNote({ text: text, title: note.title })
+          handlePreviewHide(false)
         }}
       />
     </div>
   )
 }
-
 export default InputBaseNoteText

--- a/src/components/PaperNote.tsx
+++ b/src/components/PaperNote.tsx
@@ -20,6 +20,8 @@ const PaperNote: FunctionComponent<Props> = ({ currentNoteId }) => {
 
   const [note, setNote] = useState<Note | null>(null)
 
+  const [previewHide, setPreviewHide] = useState(false)
+
   const classes = useStyles()
 
   const onUpdateNote = ({ text, title }: Change) => {
@@ -50,7 +52,7 @@ const PaperNote: FunctionComponent<Props> = ({ currentNoteId }) => {
   }, [currentNoteId])
 
   return (
-    <Paper className={classes.root}>
+    <Paper elevation={1} className={classes.root}>
       {note && (
         <TextFieldTitle
           inProgress={noteChange !== null}
@@ -60,12 +62,16 @@ const PaperNote: FunctionComponent<Props> = ({ currentNoteId }) => {
       )}
       {note && (
         <div>
-          <InputBaseNoteText
-            inProgress={noteChange !== null}
-            note={note}
-            onUpdateNote={onUpdateNote}
-          />
-          <DivNotePreview note={note} />
+          {previewHide ? (
+            <InputBaseNoteText
+              inProgress={noteChange !== null}
+              note={note}
+              onUpdateNote={onUpdateNote}
+              handlePreviewHide={setPreviewHide}
+            />
+          ) : (
+            <DivNotePreview note={note} handlePreviewHide={setPreviewHide} />
+          )}
         </div>
       )}
     </Paper>
@@ -76,7 +82,7 @@ const useStyles = makeStyles<Theme>(({ spacing }) => {
   return {
     root: {
       display: 'grid',
-      gridAutoRows: 'min-content',
+      gridAutoRows: 'min-content auto',
       gridGap: spacing(2),
       padding: spacing(2)
     }


### PR DESCRIPTION
previewをクリックするとinputに切り替わるようにした。
![lvmu4-zds9e](https://user-images.githubusercontent.com/29856021/60197626-b0229800-987a-11e9-8238-8e52c9cd6793.gif)

プレビューにhoverした時、もっと押せる感を出したい
なんかわかりにくい気もするので初期状態はプレビューで編集ボタンを置すとinputに変わって保存、キャンセルのボタンを押してまたプレビューに切り替わるとかでも良い気もしてきた。